### PR TITLE
Add path for mecab from brew on macos

### DIFF
--- a/mecab_controller.py
+++ b/mecab_controller.py
@@ -83,6 +83,7 @@ def find_best_dic_dir():
     possible_locations = (
         '/usr/lib/mecab/dic/mecab-ipadic-neologd',
         '/usr/lib/mecab/dic/ipadic',
+        '/usr/local/lib/mecab/dic/ipadic' # for `brew install mecab-ipadic`
     )
     for directory in possible_locations:
         if os.path.isdir(directory):


### PR DESCRIPTION
External mecab can be installed on macos (and some linux distros) using `brew install mecab-ipadic`.

This PR adds the corresponding path to the list of possible locations.