### PR TITLE
fix: prepend DYLD_LIBRARY_PATH & LD_LIBRARY_PATH instead of replace

### DIFF
--- a/basic_mecab_controller.py
+++ b/basic_mecab_controller.py
@@ -88,8 +88,10 @@ class BasicMecabController:
         check_mecab_rc()
         self._verbose = verbose
         self._mecab_cmd = normalize_for_platform((mecab_cmd or self._mecab_cmd) + (mecab_args or self._mecab_args))
-        os.environ["DYLD_LIBRARY_PATH"] = SUPPORT_DIR
-        os.environ["LD_LIBRARY_PATH"] = SUPPORT_DIR
+        current_dyld_library_path = os.environ.get("DYLD_LIBRARY_PATH", "")
+        current_ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
+        os.environ["DYLD_LIBRARY_PATH"] = f"{SUPPORT_DIR}:{current_dyld_library_path}" if current_dyld_library_path else SUPPORT_DIR
+        os.environ["LD_LIBRARY_PATH"] = f"{SUPPORT_DIR}:{current_ld_library_path}" if current_ld_library_path else SUPPORT_DIR
         if self._verbose:
             print("mecab cmd:", self._mecab_cmd)
 


### PR DESCRIPTION
I met an issue when using https://ankiweb.net/shared/info/1344485230 this add-on on Anki(installed via snap on Ubuntu). After digging the code, it turns out related to `LD_LIBRARY_PATH` env overrode here.

```
mpv: error while loading shared libraries: libass.so.9: cannot open shared object file: No such file or directory
Traceback (most recent call last):
  File "/snap/anki-desktop/9/lib/python3.12/site-packages/aqt/sound.py", line 878, in setup_audio
    mpvManager = MpvManager(base_folder, media_folder)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/anki-desktop/9/lib/python3.12/site-packages/aqt/sound.py", line 423, in __init__
    super().__init__(window_id=None, debug=False)
  File "/snap/anki-desktop/9/lib/python3.12/site-packages/aqt/mpv.py", line 441, in __init__
    super().__init__(*args, **kwargs)
  File "/snap/anki-desktop/9/lib/python3.12/site-packages/aqt/mpv.py", line 103, in __init__
    self._start_socket()
  File "/snap/anki-desktop/9/lib/python3.12/site-packages/aqt/mpv.py", line 193, in _start_socket
    raise MPVProcessError("unable to start process")
aqt.mpv.MPVProcessError: unable to start process
```